### PR TITLE
Updated the docker file and the project file for Worker in Lab 09-05

### DIFF
--- a/L09-05 Docker Compose - Sample App/worker/Dockerfile
+++ b/L09-05 Docker Compose - Sample App/worker/Dockerfile
@@ -1,10 +1,19 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM mcr.microsoft.com/dotnet/runtime:3.1 AS base
+WORKDIR /app
 
-WORKDIR /code
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+WORKDIR /src
+COPY ["src/Worker/Worker.csproj", "Worker/"]
+RUN dotnet restore "Worker/Worker.csproj"
+COPY . .
+WORKDIR "src/Worker"
+RUN dotnet build "Worker.csproj" -c Release -o /app/build
 
-ADD src/Worker /code/src/Worker
+FROM build AS publish
+RUN dotnet publish "Worker.csproj" -c Release -o /app/publish
 
-RUN dotnet restore -v minimal src/Worker \
-    && dotnet publish -c Release -o "./" "src/Worker/" 
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
 
-CMD dotnet src/Worker/Worker.dll
+ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/L09-05 Docker Compose - Sample App/worker/src/Worker/Worker.csproj
+++ b/L09-05 Docker Compose - Sample App/worker/src/Worker/Worker.csproj
@@ -1,13 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyName>Worker</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>Worker</PackageId>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Issues fixed:
1) .Net core 2 is no longer available - upgraded to .Net core 3.1 - was nervous about .Net 5 so just went with 3.1
2) Docker File updates to generate the .Net 3.1 project as per Visual Studio generated docker file with small modifications

